### PR TITLE
Add ability to enumerate over dict_pKeyValues

### DIFF
--- a/Dictionary.cls
+++ b/Dictionary.cls
@@ -43,6 +43,13 @@ Public Enum CompareMethod
     DatabaseCompare = VBA.vbDatabaseCompare
 End Enum
 
+' Enables 'For Each' On Dictionary Class
+' enumerates dict_pKeyValues collection
+Property Get NewEnum() As IUnknown
+  Attribute NewEnum.VB_UserMemId = -4
+  Set NewEnum = dict_pKeyValues.[_NewEnum]
+End Property
+
 Public Property Get CompareMode() As CompareMethod
 Attribute CompareMode.VB_Description = "Set or get the string comparison method."
 #If Mac Or Not UseScriptingDictionaryIfAvailable Then


### PR DESCRIPTION
If you accept pull requests, please consider adding this into the Dictionary.cls

Example of how this can be used:
Dim d as New Dictionary
d.Add "A", 1
d.Add "B", 2

Dim dItem
Debug.Print "Formatted Key, Key, Value"
For Each dItem in d
    Debug.Print dItem(0), dItem(1) , dItem(2)
Next dItem

'OUTPUT
'> Formatted Key, Key, Value
'> A A 1
'> B B 2
